### PR TITLE
Add preferences and mock data for RetroAchievements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,24 @@ A lightweight HTML/CSS/JS application for tracking RetroAchievements game comple
 - Animated spinning wheel to choose a random unfinished game
 - Management page with search, filtering and detailed editing
 - OBS overlay displaying current game information, PSFest branding and challenge progress
-- RetroAchievements API helper with caching for future integration
+- Configurable data source for RetroAchievements (API, mock data or local file) with persistent preferences
 
 ## Structure
 ```
-index.html      - navigation
-wheel.html      - random game wheel
-games.html      - game management interface
-obs.html        - streaming overlay
+index.html       - navigation
+wheel.html       - random game wheel
+games.html       - game management interface
+obs.html         - streaming overlay
+settings.html    - preferences for data source and credentials
 js/retroAchievements.js - RetroAchievements API helper
+js/preferences.js       - preferences store
 js/gameManager.js       - load/save game data
 js/wheelLogic.js        - wheel spinning logic
 js/obs.js               - overlay updates
 css/styles.css          - basic styling
 data/games.json         - sample game database
 data/settings.json      - challenge settings
+data/mock_ra.json       - mock RetroAchievements response
 ```
 
 Open `index.html` in a browser to get started.

--- a/data/mock_ra.json
+++ b/data/mock_ra.json
@@ -1,0 +1,16 @@
+[
+  {
+    "GameID": 1,
+    "Title": "Retro Game 1",
+    "Console": "NES",
+    "MaxPossible": 10,
+    "NumAchieved": 5
+  },
+  {
+    "GameID": 2,
+    "Title": "Retro Game 2",
+    "Console": "SNES",
+    "MaxPossible": 20,
+    "NumAchieved": 10
+  }
+]

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       <li><a href="wheel.html">Game Wheel</a></li>
       <li><a href="games.html">Manage Games</a></li>
       <li><a href="obs.html">OBS Display</a></li>
+      <li><a href="settings.html">Settings</a></li>
     </ul>
   </nav>
 </body>

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -1,0 +1,21 @@
+const PREF_KEY = 'app_preferences';
+
+const defaults = {
+  raDataSource: 'mock', // 'api', 'mock', 'local'
+  localDataPath: 'data/mock_ra.json',
+  username: '',
+  apiKey: ''
+};
+
+export function loadPreferences() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(PREF_KEY));
+    return stored ? { ...defaults, ...stored } : { ...defaults };
+  } catch {
+    return { ...defaults };
+  }
+}
+
+export function savePreferences(prefs) {
+  localStorage.setItem(PREF_KEY, JSON.stringify(prefs));
+}

--- a/js/retroAchievements.js
+++ b/js/retroAchievements.js
@@ -1,18 +1,35 @@
-// RetroAchievements API integration with basic caching and error handling
-const CACHE_KEY = 'ra_user_games_cache';
+import { loadPreferences } from './preferences.js';
 
-export async function fetchUserGames(username, apiKey) {
-  const cached = localStorage.getItem(CACHE_KEY);
+const CACHE_KEY = 'ra_user_games_cache';
+const MOCK_URL = 'data/mock_ra.json';
+
+export async function fetchUserGames() {
+  const prefs = loadPreferences();
+  const cacheKey = `${CACHE_KEY}_${prefs.raDataSource}`;
+  const cached = localStorage.getItem(cacheKey);
   if (cached) return JSON.parse(cached);
   try {
-    const url = `https://retroachievements.org/API/API_GetUserCompletionProgress.php?u=${username}&p=${apiKey}`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error('RA API error');
-    const data = await res.json();
-    localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+    let data;
+    if (prefs.raDataSource === 'mock') {
+      const res = await fetch(MOCK_URL);
+      data = await res.json();
+    } else if (prefs.raDataSource === 'local') {
+      const res = await fetch(prefs.localDataPath);
+      data = await res.json();
+    } else {
+      const url = `https://retroachievements.org/API/API_GetUserCompletionProgress.php?u=${prefs.username}&p=${prefs.apiKey}`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('RA API error');
+      data = await res.json();
+    }
+    localStorage.setItem(cacheKey, JSON.stringify(data));
     return data;
   } catch (e) {
-    console.error('RetroAchievements API failed', e);
+    console.error('RetroAchievements fetch failed', e);
     return [];
   }
+}
+
+export function clearRaCache() {
+  ['api', 'mock', 'local'].forEach(mode => localStorage.removeItem(`${CACHE_KEY}_${mode}`));
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "random-wheel",
   "type": "module",
   "scripts": {
-    "test": "node --check js/gameManager.js js/wheelLogic.js js/obs.js js/retroAchievements.js"
+    "test": "node --check js/gameManager.js js/wheelLogic.js js/obs.js js/retroAchievements.js js/preferences.js"
   }
 }

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Settings</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <h1>Settings</h1>
+  <form id="prefsForm">
+    <label>Data Source
+      <select id="raDataSource">
+        <option value="api">RetroAchievements API</option>
+        <option value="mock">Mock Data</option>
+        <option value="local">Local JSON File</option>
+      </select>
+    </label>
+    <label id="usernameLabel">RA Username <input id="username"></label>
+    <label id="apiKeyLabel">RA API Key <input id="apiKey"></label>
+    <label id="localFileLabel">Local File <input id="localFile" placeholder="data/mock_ra.json"></label>
+    <button type="submit">Save</button>
+  </form>
+  <script type="module">
+    import { loadPreferences, savePreferences } from './js/preferences.js';
+    const form = document.getElementById('prefsForm');
+    const raDataSource = document.getElementById('raDataSource');
+    const username = document.getElementById('username');
+    const apiKey = document.getElementById('apiKey');
+    const localFile = document.getElementById('localFile');
+    const usernameLabel = document.getElementById('usernameLabel');
+    const apiKeyLabel = document.getElementById('apiKeyLabel');
+    const localFileLabel = document.getElementById('localFileLabel');
+
+    const prefs = loadPreferences();
+    raDataSource.value = prefs.raDataSource;
+    username.value = prefs.username;
+    apiKey.value = prefs.apiKey;
+    localFile.value = prefs.localDataPath;
+
+    function updateVisibility() {
+      const mode = raDataSource.value;
+      usernameLabel.style.display = mode === 'api' ? '' : 'none';
+      apiKeyLabel.style.display = mode === 'api' ? '' : 'none';
+      localFileLabel.style.display = mode === 'local' ? '' : 'none';
+    }
+    raDataSource.addEventListener('change', updateVisibility);
+    updateVisibility();
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      savePreferences({
+        raDataSource: raDataSource.value,
+        username: username.value,
+        apiKey: apiKey.value,
+        localDataPath: localFile.value
+      });
+      alert('Preferences saved');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add preferences store with persistent configuration
- Allow selecting RetroAchievements data source (API, mock data, or local file)
- Introduce settings page and mock RetroAchievements dataset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a82cca790c83309eb3e36c67599ccb